### PR TITLE
feat: add support for latest SDL2 including the battery update event

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: sudo apt-get update
       - run: sudo apt install -y build-essential cmake libsdl2-dev
       - run: npm ci
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: sudo apt-get update
       - run: sudo apt install -y build-essential cmake git
       - run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Install SDL2 with brew
         run: brew install sdl2
       - name: Compile

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: sudo apt-get update
       - run: sudo apt install -y build-essential cmake libsdl2-dev
       - run: npm ci
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm publish
         env:
@@ -42,7 +42,7 @@ jobs:
   #    - uses: actions/checkout@v2
   #    - uses: actions/setup-node@v2
   #      with:
-  #        node-version: 14
+  #        node-version: 16
   #        registry-url: https://npm.pkg.github.com/
   #    - run: npm publish --registry=https://npm.pkg.github.com/
   #      env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(sdl_gamecontroller CXX)
 message(STATUS "Build type ${CMAKE_BUILD_TYPE}")
 
 # Add SDL2
-find_package(SDL2 REQUIRED)
+find_package(SDL2 REQUIRED
+    HINTS /home/linuxbrew/.linuxbrew/lib/cmake
+    )
 if(IS_DIRECTORY "${SDL2_INCLUDE_DIRS}")
  get_filename_component(SDL2_PARENT_DIR ${SDL2_INCLUDE_DIRS} DIRECTORY)
  message(STATUS "Found SDL2 includes in ${SDL2_INCLUDE_DIRS} in ${SDL2_PARENT_DIR}")

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,10 @@
+# v1.0.10
+- Add controller battery events
+- Fix build issue with brew on Linux
+
+# v1.0.9
+- Add support for apple M1
+
 # v1.0.8
 - Issue warning for mismatch params instead of throwing error. Resolve issue where a param is passed to `rumble` or another function but the param was undefined and an error is thrown. This was particularly an issue for the player number which is often not supported.
 
@@ -6,5 +13,4 @@
 - Add support for setting the polling interval
 
 # v1.0.6
-
 - Add typescript support

--- a/docs/API.md
+++ b/docs/API.md
@@ -266,13 +266,14 @@ Emitted when Game controller battery is updated
 ```js
 // SDL 2.0.24+
 {
-  message: 'Game controller battery was updated',
-  timestamp: "tbd",
+  message: 'Game controller battery was updated', 
   which: 0,
+  timestamp: 498,
   level: "low"
 }
 ```
-The `level` field will be one of "empty", "low", "medium", "full", "wired", "max", or "unknown"
+- The `level` field will be one of "empty", "low", "medium", "full", "wired", "max", or "unknown".
+- The `timestamp` in milliseconds is relative to the start of node process.
 
 ## accelerometer:enabled
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,7 @@ const gamecontroller = require('sdl2-gamecontroller/custom')(options)
 - [controller-device-removed](#controller-device-removed)
 - [controller-device-remapped](#controller-device-remapped)
 - [controller-sensor-update](#controller-sensor-update)
+- [controller-battery-update](#controller-battery-update)
 - [accelerometer:enabled](#accelerometerenabled)
 - [accelerometer:disabled](#accelerometerdisabled)
 - [gyroscope:enabled](#gyroscopeenabled)
@@ -247,7 +248,6 @@ Emitted when Game controller sensor is updated
   z: 1.527079463005066
 }
 ```
-
 An alias for this event is also emitted with the event name set to either `gyroscope` or `accelerometer`.
 
 For example:
@@ -257,6 +257,22 @@ gamecontroller.on('gyroscope', (data) =>
   console.log('gyroscope updated', data),
 );
 ```
+
+## controller-battery-update
+
+Emitted when Game controller battery is updated
+[SDL_JOYBATTERYUPDATED](https://wiki.libsdl.org/SDL2/SDL_JoystickPowerLevel)
+
+```js
+// SDL 2.0.24+
+{
+  message: 'Game controller battery was updated',
+  timestamp: 0, 
+  which: 0,
+  level: "low"
+}
+```
+The `level` field will be one of "empty", "low", "medium", "full", "wired", "max", or "unknown"
 
 ## accelerometer:enabled
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -267,7 +267,7 @@ Emitted when Game controller battery is updated
 // SDL 2.0.24+
 {
   message: 'Game controller battery was updated',
-  timestamp: 0, 
+  timestamp: "tbd",
   which: 0,
   level: "low"
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,7 @@ export type DeviceUpdated = Message & {
 export type DeviceUpdateEvents =
   | 'controller-device-removed'
   | 'controller-device-remapped';
+export type BatteryUpdateEvents = 'controller-battery-update';
 
 export type AxisType =
   | 'leftx'
@@ -103,6 +104,20 @@ export type ButtonTypeWithUpsAndDowns =
 export type ControllerButtonDown = Message &
   Player & {button: ButtonType; pressed: boolean};
 
+export type BatteryLevelType =
+  | 'empty'
+  | 'low'
+  | 'medium'
+  | 'full'
+  | 'wired'
+  | 'max'
+  | 'unknown';
+export type BatteryUpdate = Message &
+  DeviceUpdated & {
+    timestamp: number;
+    level: BatteryLevelType;
+  };
+
 export type CallBack<T = Record<string, unknown>> = (data: T) => void;
 
 type ON<TEventName, TCallBack> = (
@@ -115,6 +130,7 @@ type OnWarningCall = ON<'warning', Warning>;
 type OnSdlInitCall = ON<'sdl-init', SdlInit>;
 type OnDeviceAddedCall = ON<'controller-device-added', DeviceAdded>;
 type OnDeviceUpdated = ON<DeviceUpdateEvents, DeviceUpdated>;
+type OnBatteryUpdated = ON<BatteryUpdateEvents, BatteryUpdate>;
 type OnAxisUpdate = ON<AxisType, AxisMotionData>;
 type OnButtonPressCall = ON<ButtonTypeWithUpsAndDowns, ButtonPress>;
 type OnSensorUpdate = ON<SensorUpdateEvents, SensorUpdate>;
@@ -131,6 +147,7 @@ type AllOnOptions = OnButtonPressCall &
   OnSdlInitCall &
   OnDeviceAddedCall &
   OnDeviceUpdated &
+  OnBatteryUpdated &
   OnSensorUpdate &
   OnSensorStateChange &
   OnTouchpadUpdate &

--- a/src/sdlgamecontroller.cpp
+++ b/src/sdlgamecontroller.cpp
@@ -230,6 +230,18 @@ Napi::Value SdlGameController::pollEvents(const Napi::CallbackInfo &info) {
       SDL_SetHint(SDL_HINT_JOYSTICK_ROG_CHAKRAM, "1");
     }
 #endif
+#if SDL_VERSION_ATLEAST(2, 0, 24)
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SHIELD, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 26)
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX_360, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX_360_PLAYER_LED, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX_360_WIRELESS, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX_ONE, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX_ONE_HOME_LED, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII_PLAYER_LED, "1");
+#endif
+
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER)
         < 0) {
@@ -443,6 +455,36 @@ Napi::Value SdlGameController::pollEvents(const Napi::CallbackInfo &info) {
             break;
         }
         emit({Napi::String::New(env, "controller-sensor-update"), obj});
+        break;
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 24)
+      case SDL_JOYBATTERYUPDATED:
+        obj.Set("message", "Game controller battery was updated");
+        obj.Set("timestamp", event.jbattery.timestamp);
+        obj.Set("which", static_cast<int>(event.jbattery.which));
+        switch (event.jbattery.level) {
+            case SDL_JOYSTICK_POWER_EMPTY:
+                obj.Set("level", "empty");
+                break;
+            case SDL_JOYSTICK_POWER_LOW:
+                obj.Set("level", "low");
+                break;
+            case SDL_JOYSTICK_POWER_MEDIUM:
+                obj.Set("level", "medium");
+                break;
+            case SDL_JOYSTICK_POWER_FULL:
+                obj.Set("level", "full");
+                break;
+            case SDL_JOYSTICK_POWER_WIRED:
+                obj.Set("level", "wired");
+                break;
+            case SDL_JOYSTICK_POWER_MAX:
+                obj.Set("level", "max");
+                break;
+            default:
+                obj.Set("level", "unknown");
+        }
+        emit({Napi::String::New(env, "controller-battery-update"), obj});
         break;
 #endif
         // LIMITED support for keyboard events - probably only helpful for

--- a/src/sdlgamecontroller.cpp
+++ b/src/sdlgamecontroller.cpp
@@ -242,7 +242,6 @@ Napi::Value SdlGameController::pollEvents(const Napi::CallbackInfo &info) {
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII_PLAYER_LED, "1");
 #endif
 
-
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER)
         < 0) {
       emit({Napi::String::New(env, "error"),
@@ -463,26 +462,26 @@ Napi::Value SdlGameController::pollEvents(const Napi::CallbackInfo &info) {
         obj.Set("timestamp", event.jbattery.timestamp);
         obj.Set("which", static_cast<int>(event.jbattery.which));
         switch (event.jbattery.level) {
-            case SDL_JOYSTICK_POWER_EMPTY:
-                obj.Set("level", "empty");
-                break;
-            case SDL_JOYSTICK_POWER_LOW:
-                obj.Set("level", "low");
-                break;
-            case SDL_JOYSTICK_POWER_MEDIUM:
-                obj.Set("level", "medium");
-                break;
-            case SDL_JOYSTICK_POWER_FULL:
-                obj.Set("level", "full");
-                break;
-            case SDL_JOYSTICK_POWER_WIRED:
-                obj.Set("level", "wired");
-                break;
-            case SDL_JOYSTICK_POWER_MAX:
-                obj.Set("level", "max");
-                break;
-            default:
-                obj.Set("level", "unknown");
+          case SDL_JOYSTICK_POWER_EMPTY:
+            obj.Set("level", "empty");
+            break;
+          case SDL_JOYSTICK_POWER_LOW:
+            obj.Set("level", "low");
+            break;
+          case SDL_JOYSTICK_POWER_MEDIUM:
+            obj.Set("level", "medium");
+            break;
+          case SDL_JOYSTICK_POWER_FULL:
+            obj.Set("level", "full");
+            break;
+          case SDL_JOYSTICK_POWER_WIRED:
+            obj.Set("level", "wired");
+            break;
+          case SDL_JOYSTICK_POWER_MAX:
+            obj.Set("level", "max");
+            break;
+          default:
+            obj.Set("level", "unknown");
         }
         emit({Napi::String::New(env, "controller-battery-update"), obj});
         break;

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -6,10 +6,10 @@ gamecontroller.on('sdl-init', (data) => console.log('SDL2 Initialized', data));
 gamecontroller.on('a:down', () => console.log('Hello A button world'));
 gamecontroller.on('controller-device-added', (data) => {
   console.log('controller connected', data.name);
-  gamecontroller.rumble("bad",{bad:true}, false, undefined);
-  gamecontroller.rumbleTriggers("bad",{bad:true}, false, undefined);
+  gamecontroller.rumble('bad', {bad: true}, false, undefined);
+  gamecontroller.rumbleTriggers('bad', {bad: true}, false, undefined);
   gamecontroller.enableGyroscope(1, null);
-  gamecontroller.enableAccelerometer(0, "one");
-  gamecontroller.setLeds(undefined, false, "blue", "");
+  gamecontroller.enableAccelerometer(0, 'one');
+  gamecontroller.setLeds(undefined, false, 'blue', '');
   process.exit(0);
 });

--- a/test/lengthy.js
+++ b/test/lengthy.js
@@ -102,4 +102,9 @@ gamecontroller.on('controller-button-down', (data) =>
   console.log('button pressed', data),
 );
 
+// Print information about the controller battery
+gamecontroller.on('controller-battery-update', (data) =>
+  console.log('battery update', data),
+);
+
 gamecontroller.on('back', () => process.exit(0));

--- a/test/lengthy.ts
+++ b/test/lengthy.ts
@@ -96,7 +96,7 @@ gamecontroller.on('controller-touchpad-motion', (data) =>
   ),
 );
 
-gamecontroller.on('led', (data) => console.log('LEDS set', data));
+gamecontroller.on('led', (data) => console.log('LEDs set', data));
 
 // Respond to both up & down events
 gamecontroller.on('leftshoulder', (data) =>
@@ -108,6 +108,10 @@ gamecontroller.on('leftshoulder', (data) =>
 // Print information about a pressed button
 gamecontroller.on('controller-button-down', (data) =>
   console.log('button pressed', data),
+);
+
+gamecontroller.on('controller-battery-update', (data) =>
+  console.log('battery update', data),
 );
 
 gamecontroller.on('back', () => process.exit(0));


### PR DESCRIPTION
- update CMake for build on macos with brew
- added support for [SDL_JOYBATTERYUPDATED](https://wiki.libsdl.org/SDL2/SDL_JoystickPowerLevel) with `controller-battery-update` event
- Add hints for xBox and Wii controllers